### PR TITLE
Create button instead of class

### DIFF
--- a/app/components/Button.jsx
+++ b/app/components/Button.jsx
@@ -1,15 +1,25 @@
 'use client'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
-function Button({ error, toggle, children }) {
-    const [background, setBackground] = useState('#1ED760');
+function Button({ state, toggle=()=>{}, children }) {
+    const [backgroundHex, setBackgroundHex] = useState(`#707070`);
 
-    if(error) setBackground('#D71E1E');
+    useEffect(() => {
+        switch (state) {
+            case 'successful': setBackgroundHex(`#1ED760`)
+                break;
+            case 'loading': setBackgroundHex(`#707070`)
+                break;
+            case 'error': setBackgroundHex(`#D71E1E`)
+                break;
+            default: setBackgroundHex(`#707070`);
+        }
+    }, [state])
 
     return (
-        <Button className={`w-72 h-14 rounded-bl-3xl bg-[${background}] shadow-xl hover:opacity-80 active:scale-95`} onClick={()=> toggle()}>
-            {children}
-        </Button>
+        <button className={`w-72 sm:h-14 h-12 rounded-3xl bg-[${backgroundHex}] shadow-lg hover:opacity-80 active:scale-95`} onClick={() => toggle()}>
+            <h1 className='song-title-bold'>{children}</h1>
+        </button>
     )
 }
 

--- a/app/components/Button.jsx
+++ b/app/components/Button.jsx
@@ -1,0 +1,16 @@
+'use client'
+import { useState } from 'react'
+
+function Button({ error, toggle, children }) {
+    const [background, setBackground] = useState('#1ED760');
+
+    if(error) setBackground('#D71E1E');
+
+    return (
+        <Button className={`w-72 h-14 rounded-bl-3xl bg-[${background}] shadow-xl hover:opacity-80 active:scale-95`} onClick={()=> toggle()}>
+            {children}
+        </Button>
+    )
+}
+
+export default Button

--- a/app/globals.css
+++ b/app/globals.css
@@ -66,18 +66,6 @@ p {
   font-weight: 200;
 }
 
-.btn-primary {
-  width: 18rem;
-  height: 3.7rem;
-  border-radius: 1.8rem;
-  background: #1ED760;
-  box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
-}
-
-button.error {
-  background: #D71E1E;
-}
-
 .btn-spotify {
   width: 31rem;
   height: 6.8rem;
@@ -85,11 +73,11 @@ button.error {
   background: url("../public/asstes/img/spotify.png"), lightgray 50% / cover no-repeat;
 }
 
-.btn-primary, .btn-spotify:hover {
+.btn-spotify:hover {
   opacity: .8;
 }
 
-.btn-primary, .btn-spotify:active{
+.btn-spotify:active{
   transform: scale(.99);
 }
 
@@ -127,10 +115,5 @@ button.error {
     width: 20.6rem;
     height: 5.3rem;
     background: url("../public/asstes/img/spotify-responsive.png"), lightgray 50% / cover no-repeat;
-  }
-
-  .btn-primary {
-    width: 18rem;
-    height: 3rem;
   }
 }

--- a/app/page.js
+++ b/app/page.js
@@ -1,6 +1,7 @@
 'use client'
 import { signOut, useSession } from 'next-auth/react'
 import Login from './components/Login'
+import Button from './components/Button';
 
 export default function Home() {
   const { data: session } = useSession();
@@ -8,7 +9,7 @@ export default function Home() {
     return (
       <div>
         <h1 className='title-bold'>Welcome {session?.token?.name}</h1>
-        <button onClick={() => signOut()}>Sign Out</button>
+        <Button error={false} toggle={signOut}>Sign Out</Button>
       </div>
     )
   } else {

--- a/app/page.js
+++ b/app/page.js
@@ -9,7 +9,10 @@ export default function Home() {
     return (
       <div>
         <h1 className='title-bold'>Welcome {session?.token?.name}</h1>
-        <Button error={false} toggle={signOut}>Sign Out</Button>
+        <Button state={'loading'} >Sign Out</Button>
+        <Button state={'error'} >Sign Out</Button>
+        <Button state={'successful'} toggle={signOut} >Sign Out</Button>
+        <Button state={'j'} toggle={signOut} >default</Button>
       </div>
     )
   } else {


### PR DESCRIPTION
I created a new `Button` component instead of a `css class`. 
It displays into the page like this: 

![ButtonInsteadOfClass](https://github.com/Matdweb/Jamming/assets/110640534/5c71f117-0dbd-4930-b0dc-ef8f6a336f20)

## About the `Button` component
the component fulfilled the styles and behavior establish in the #13 ticket, but according to the [Figma design](https://www.figma.com/file/ce0bwas2kwugzVs2vS6Hri/Jamming?type=design&node-id=7%3A185&mode=design&t=g4fVGnMvkYlLFme0-1)  the button has also a `loading state`. So I also add that

##`Button` states
This `button` may have different states (info that determines the styles of the element). In this case, we can have `error`, `loading` and `successful` states. This will define the `background-color` of the `button`.  Like this: 

> When `'loading'` or an `invalid` state is given
![image](https://github.com/Matdweb/Jamming/assets/110640534/d24a3e87-7541-4870-a835-06a20838d979)

> When `'successful'`  state is given
![image](https://github.com/Matdweb/Jamming/assets/110640534/19f569d5-850c-4b68-9408-1c1de4956682)

> When `'error'` state is given
![image](https://github.com/Matdweb/Jamming/assets/110640534/4aecab23-ef42-4322-b1df-8ed462fb6cb9)


### About this PR
This PR creates a `Button` component.
- This component receives `state`, and `toggle` attributes. So it gives the `Button` the ability to change its styles based on a state and execute a `function/toggle` when an `onClick` event triggers!
- And it doesn't modify the page behavior