### PR TITLE
create a inline background style to fix bug

### DIFF
--- a/app/components/Button.jsx
+++ b/app/components/Button.jsx
@@ -17,7 +17,11 @@ function Button({ state, toggle=()=>{}, children }) {
     }, [state])
 
     return (
-        <button className={`w-72 sm:h-14 h-12 rounded-3xl bg-[${backgroundHex}] shadow-lg hover:opacity-80 active:scale-95`} onClick={() => toggle()}>
+        <button 
+        className={`w-72 sm:h-14 h-12 rounded-full shadow-lg hover:opacity-80 active:scale-95`} 
+        onClick={() => toggle()}
+        style={{backgroundColor: backgroundHex}}
+        >
             <h1 className='song-title-bold'>{children}</h1>
         </button>
     )

--- a/app/components/PlaylistContainer.jsx
+++ b/app/components/PlaylistContainer.jsx
@@ -40,7 +40,7 @@ function PlaylistContainer() {
                     })}
                 </div>
                 <div className='w-full pt-6 flex justify-center sm:justify-end items-center ml-0 sm:ml-6'>
-                    <Button state={'l'}>Save this in Spotify</Button>
+                    <Button state={'loading'}>Save this in Spotify</Button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
It seems like the bug is fixed!
Take a look!
![image](https://github.com/Matdweb/Jamming/assets/110640534/369790cf-9d28-4322-88e8-4f777ee17485)

## About this PR
I just removed the `bg-[]` **tailwind property** and add an **inline-style** to the element. Setting this way the `backgroundColor` property to the `backgroundHex` value