### PR TITLE
Retrieve access token from spotify api

### DIFF
--- a/app/api/auth/[...nextauth]/options.js
+++ b/app/api/auth/[...nextauth]/options.js
@@ -1,12 +1,13 @@
 import SpotifyProvider from 'next-auth/providers/spotify'
+import { SpotifyCredentials } from '@/lib/Spotify/spotifySearchCredentials';
 
 export default {
     providers: [
         SpotifyProvider({
             authorization:
                 'https://accounts.spotify.com/authorize?scope=user-read-email,playlist-read-private,playlist-modify-private,playlist-modify-public',
-            clientId: process.env.SPOTIFY_CLIENT_ID,
-            clientSecret: process.env.SPOTIFY_CLIENT_SECRET,
+            clientId: SpotifyCredentials.client_id,
+            clientSecret: SpotifyCredentials.client_secret,
         }),
     ],
     callbacks: {

--- a/app/api/spotify/accessToken/route.js
+++ b/app/api/spotify/accessToken/route.js
@@ -1,0 +1,23 @@
+import { SpotifyCredentials } from "@/lib/Spotify/spotifySearchCredentials";
+import { NextResponse } from "next/server";
+
+export async function POST(request) {
+    const { refresh_token } = await request.json();
+
+    const response = await fetch(SpotifyCredentials.TOKEN_ENDPOINT, {
+        method: 'POST',
+        headers: {
+            Authorization: 'Basic ' + SpotifyCredentials.basic,
+            'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+            grant_type: "refresh_token",
+            refresh_token,
+            code: refresh_token,
+            redirect_uri: 'http://localhost:3000/api/auth/callback/spotify',
+        }),
+    });
+
+    const {access_token, expires_in} = await response.json()
+    return NextResponse.json({access_token, expires_in})
+}

--- a/app/components/PlaylistContainer.jsx
+++ b/app/components/PlaylistContainer.jsx
@@ -5,21 +5,24 @@ import Button from "./Button";
 import SpotifySongs from "@/lib/Spotify/songs";
 import { useContext } from 'react';
 import { SpotifyContext } from '@/context/SpotifyContextProvider';
+import { useSession } from "next-auth/react";
 
 function PlaylistContainer() {
     const [playlistName, setPlaylistName] = useState('New Playlist');
-
     const [songs, setSongs] = useState(SpotifySongs);
 
-    const { token } = useContext(SpotifyContext);
+    const { data: session } = useSession();
+    const refresh_token = session?.token.accessToken;
+    const { token: { getAccessToken } } = useContext(SpotifyContext);
 
     const handleChange = ({ target }) => {
         setPlaylistName(target.value);
     }
 
-    useEffect(()=> {
-        token.setAccessToken('a new cool access token')
-    })
+    const testGetAccessToken = async () => {
+        const data = await getAccessToken(refresh_token);
+        console.log(data);
+    }
 
     return (
         <div className='max-w-[44rem] flex justify-center items-center sm:px-8 pb-9'>
@@ -48,7 +51,7 @@ function PlaylistContainer() {
                     })}
                 </div>
                 <div className='w-full pt-6 flex justify-center sm:justify-end items-center ml-0 sm:ml-6'>
-                    <Button state={'loading'} toggle={()=> console.log(token.accessToken)}>Save this in Spotify</Button>
+                    <Button state={'loading'} toggle={async () => await testGetAccessToken()}>Save this in Spotify</Button>
                 </div>
             </div>
         </div>

--- a/context/SpotifyContextProvider.jsx
+++ b/context/SpotifyContextProvider.jsx
@@ -1,17 +1,28 @@
 'use client'
-import { createContext, useState } from 'react'
+import { createContext, useEffect, useState } from 'react'
+import requestAccessToken from './requestAccessToken';
+import { useSession } from 'next-auth/react';
 
 export const SpotifyContext = createContext()
 
 function SpotifyContextProvider({ children }) {
-    const [accessToken, setAccessToken] = useState('an access token');
+    const [accessToken, setAccessToken] = useState(null);
 
-    const state={
+    const getAccessToken = async (refresh_token) => {
+        if (accessToken) {
+            console.log('Theres already a token')
+            return accessToken;
+        }
+        return await requestAccessToken(refresh_token, setAccessToken);
+    }
+
+    const state = {
         token: {
-            accessToken,
+            getAccessToken,
             setAccessToken
         }
     }
+
     return (
         <SpotifyContext.Provider value={state}>
             {children}

--- a/context/requestAccessToken.js
+++ b/context/requestAccessToken.js
@@ -1,0 +1,33 @@
+const requestAccessToken = async (refresh_token, setAccessToken) => {
+
+    const response = await fetch('api/spotify/accessToken', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            refresh_token,
+        })
+    });
+
+    try {
+        const data = await response.json();
+        
+        setAccessToken(data.access_token);
+        handleAccessTokenExpiration(data.expires_in, setAccessToken)
+        return data.access_token;
+    } catch (e) {
+        console.log(e);
+        return null;
+    }
+}
+
+const handleAccessTokenExpiration = async (time, setAccessToken) => {
+    setTimeout(() => {
+      setAccessToken(null);
+      console.log('token expired')
+    }, time*1000)
+  }
+
+
+export default requestAccessToken;

--- a/lib/Spotify/spotifySearchCredentials.js
+++ b/lib/Spotify/spotifySearchCredentials.js
@@ -1,0 +1,14 @@
+//client credentials
+const client_id = process.env.SPOTIFY_CLIENT_ID;
+const client_secret = process.env.SPOTIFY_CLIENT_SECRET;
+//String created combining the client credentials in a base64 string
+const basic = Buffer.from(`${client_id}:${client_secret}`).toString('base64');
+//TOKEN_ENDOPOINT the url to make the access token request 
+const TOKEN_ENDPOINT = `https://accounts.spotify.com/api/token`;
+
+export const SpotifyCredentials = {
+    client_id,
+    client_secret,
+    basic,
+    TOKEN_ENDPOINT,
+}


### PR DESCRIPTION
# About this Pull Request
As explain in the #20 ticket we need an `access-token` to start making other requests to the Spotify API. This, after we already have an **authenticated user** and a valid `session-token`.
Learn more about the **app state manager** in #21 pull request. 

Here you will find the step by step of: 
- **How did we retrieve an access token from Spotify API?** 
- **How did we store this token in the app?**
- **A short functionality test**

## How do we retrieve an access token?
First, as explained previously we need a valid `session-token`. This is accomplish using the `useSession()` from [nextAuth](https://next-auth.js.org/getting-started/example), learn about it [here](https://next-auth.js.org/getting-started/example), and learn about this app authentication with #14 PR. 

**Once we have the `session-token`:**
- In the `SpotifyContext` we created a `getAccessToken()` function. 
- This function checks **IF** there's already a valid `access-token` then just return it, **ELSE** request a new `access-token`  from the `Spotify API`. 
- If we need to request a new `access-token` we use the `requestAccessToken()` function
>  we need to pass the `refresh-token` _(session-token)_  and the `setAccessToken()` as parameters
- In the `requestAccessToken()` we make a `POST` request to the `api/spotify/accessToken` endpoint of the application.  This request should like this: 
![image](https://github.com/Matdweb/Jamming/assets/110640534/bd578b33-9d37-4e82-a0c5-0c434982a20b)
_Important passing the `session-token` in the body_

- At the end, if everything goes right the `accessToken` should **globally** be updated to the new **value**.
- The **expiration process** should be handled
- And the value should be returned

# `api/spotify/accessToken`
This endpoint is created to make requests in the backend because of **security and best practices**. 
In here we: 
- retrieve the `refresh-token` from the body of the request 
- Then we make a `POST` request to [https://accounts.spotify.com/api/token](https://accounts.spotify.com/api/token) endpoint
- The request should look like this:
![image](https://github.com/Matdweb/Jamming/assets/110640534/6f0f8f21-5280-4873-852c-358bf8a2335c)
Being the `SpotifyCredentials.basic` the **basic 64-bits** combination between `SPOTIFY_CLIENT_ID` & `SPOTIFY_CLIENT_SECRET`. 

- At the end, if everything goes right we should return a `NextResponse` with the `access_token` and the `expiration-time`

## Storage in SpotifyContext
Now, everytime the `getAccessToken()` is called anyware. This checks if there's an access-token. If there's not, then request it. 
So, by making the call to this function, in the client, the **state** should **always** be updated with a **valid value**.

### How to retrieve the access token in the client? 
1. retrive the **session** using the `useSession()` method
2. retrieve the `session-token` in the session, like this: `session?.token.accessToken`
3. use the `spotifyContext` using the `useContext()`, learn more [here](https://react.dev/reference/react/useContext)
4. retrieve the `getAccessToken()` form the **Context**
5. call the previous function using the `refresh-token` as **parameter**

This should look like this: 
![image](https://github.com/Matdweb/Jamming/assets/110640534/dbe22928-7b45-486a-ba3d-802a1cbf91d4)


### Test
As established in ticket #20 a test for this functionality was created with the `'Save this in Spotify'` **Button**
**IMPORTANT**: the token `expiration-time` was reduced for **test purposes**, but in the final code we set the **right time expiration**

![retrieveAccessToken](https://github.com/Matdweb/Jamming/assets/110640534/624c1d05-6e25-4e41-b48d-29dd034d478d)