### PR TITLE
fix inter className error

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -18,7 +18,7 @@ export default function RootLayout({ children }) {
     <html lang="en">
       <AuthProvider>
         <SpotifyContextProvider>
-        <body className={inter.className + 'w-full min-h-screen bg-green-500'}>
+        <body className={inter.className + ' w-full min-h-screen bg-green-500'}>
           <section className='text-center mt-16 sm:mt-24'>
             <h2 className='header-black'>Create your custom playlist with</h2>
             <h1 className='black-title'>Jamming</h1>


### PR DESCRIPTION
## Bug/error
The error was that the `<body>` tag had the `className` for the `Inter` font, but the rest of the `tailwind css` styles were just right beside this, giving then a invalid inter `className`
See here: 
![image](https://github.com/Matdweb/Jamming/assets/110640534/e1aca46c-5bef-4e2a-915c-803ef0e7a50b)

## Solution
Now it's fixed just adding a blank space in between: 
![image](https://github.com/Matdweb/Jamming/assets/110640534/f13ec1c2-af51-4dc2-b71c-0e0cc8ee0175)
Figma: 
![image](https://github.com/Matdweb/Jamming/assets/110640534/3092b8ac-3119-4fe6-b898-786b7e906501)
