### PR TITLE
Create button animations

### DIFF
--- a/app/components/Button.jsx
+++ b/app/components/Button.jsx
@@ -1,9 +1,10 @@
 'use client'
 import { useEffect, useState } from 'react'
 
-function Button({ color, toggle = () => { }, children }) {
+function Button({ color, toggle = async () => { }, children }) {
     const [backgroundHex, setBackgroundHex] = useState(`#707070`);
     const [isBlocked, setIsBlocked] = useState(true);
+    const [loadAnimation, setLoadAnimation] = useState(false);
 
     const handleButtonColor = () => {
         switch (color) {
@@ -23,7 +24,7 @@ function Button({ color, toggle = () => { }, children }) {
         setTimeout(()=> {
             setBackgroundHex(`#1ED760`);
             setIsBlocked(false);
-        }, 2500)
+        }, 3000)
     }
 
     const handleLoading = () => {
@@ -38,8 +39,9 @@ function Button({ color, toggle = () => { }, children }) {
 
     const handleToggle = async () => {
         if (!isBlocked) {
-           toggle();
-
+           const res = await toggle();
+            if(res) setLoadAnimation(true);
+            setTimeout(()=> {setLoadAnimation(false)}, 3000)
         }
     }
 
@@ -49,7 +51,7 @@ function Button({ color, toggle = () => { }, children }) {
 
     return (
         <button
-            className={`loading-button w-72 sm:h-14 h-12 rounded-full shadow-lg cursor-not-allowed ${!isBlocked ? `cursor-pointer hover:opacity-80 active:scale-95` : ``}`}
+            className={` w-72 sm:h-14 h-12 rounded-full shadow-lg cursor-not-allowed ${!isBlocked ? `cursor-pointer hover:opacity-80 active:scale-95` : ``} ${loadAnimation ? `loading-button` : ``}`}
             onClick={() => handleToggle()}
             style={{ backgroundColor: backgroundHex }}
         >

--- a/app/components/Button.jsx
+++ b/app/components/Button.jsx
@@ -1,26 +1,57 @@
 'use client'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useContext } from 'react'
+import { SpotifyContext } from '@/context/SpotifyContextProvider';
 
-function Button({ state, toggle=()=>{}, children }) {
+function Button({ state, toggle = () => { }, children }) {
     const [backgroundHex, setBackgroundHex] = useState(`#707070`);
+    const [isBlocked, setIsBlocked] = useState(true);
+
+    const handleButtonState = () => {
+        switch (state) {
+            case 'successful': handleSuccessful(); break;
+
+            case 'loading': handleLoading(); break;
+
+            case 'error': handleError(); break;
+
+            default: setBackgroundHex(`#707070`); setIsBlocked(false);
+        }
+    }
+
+    const handleError = () => {
+        setBackgroundHex(`#D71E1E`);
+        setIsBlocked(true);
+        setTimeout(()=> {
+            setBackgroundHex(`#1ED760`);
+            setIsBlocked(false);
+        }, 4000)
+    }
+
+    const handleLoading = () => {
+        setBackgroundHex(`#707070`);
+        setIsBlocked(true);
+    }
+
+    const handleSuccessful = () => {
+        setBackgroundHex(`#1ED760`)
+        setIsBlocked(false);
+    }
+
+    const handleToggle = async () => {
+        if (!isBlocked) {
+            toggle();
+        }
+    }
 
     useEffect(() => {
-        switch (state) {
-            case 'successful': setBackgroundHex(`#1ED760`)
-                break;
-            case 'loading': setBackgroundHex(`#707070`)
-                break;
-            case 'error': setBackgroundHex(`#D71E1E`)
-                break;
-            default: setBackgroundHex(`#707070`);
-        }
+        handleButtonState();
     }, [state])
 
     return (
-        <button 
-        className={`w-72 sm:h-14 h-12 rounded-full shadow-lg hover:opacity-80 active:scale-95`} 
-        onClick={() => toggle()}
-        style={{backgroundColor: backgroundHex}}
+        <button
+            className={`w-72 sm:h-14 h-12 rounded-full cursor-blocked shadow-lg hover:opacity-80 active:scale-95 ${isBlocked ? `cursor-not-allowed active:scale-100 hover:opacity-100` : ''}`}
+            onClick={() => handleToggle()}
+            style={{ backgroundColor: backgroundHex }}
         >
             <h1 className='song-title-bold'>{children}</h1>
         </button>

--- a/app/components/Button.jsx
+++ b/app/components/Button.jsx
@@ -1,20 +1,19 @@
 'use client'
-import { useEffect, useState, useContext } from 'react'
-import { SpotifyContext } from '@/context/SpotifyContextProvider';
+import { useEffect, useState } from 'react'
 
-function Button({ state, toggle = () => { }, children }) {
+function Button({ color, toggle = () => { }, children }) {
     const [backgroundHex, setBackgroundHex] = useState(`#707070`);
     const [isBlocked, setIsBlocked] = useState(true);
 
-    const handleButtonState = () => {
-        switch (state) {
-            case 'successful': handleSuccessful(); break;
+    const handleButtonColor = () => {
+        switch (color) {
+            case 'green': handleSuccessful(); break;
 
-            case 'loading': handleLoading(); break;
+            case 'gray': handleLoading(); break;
 
-            case 'error': handleError(); break;
+            case 'red': handleError(); break;
 
-            default: setBackgroundHex(`#707070`); setIsBlocked(false);
+            default: setBackgroundHex(`#00000`); setIsBlocked(false);
         }
     }
 
@@ -24,7 +23,7 @@ function Button({ state, toggle = () => { }, children }) {
         setTimeout(()=> {
             setBackgroundHex(`#1ED760`);
             setIsBlocked(false);
-        }, 4000)
+        }, 2500)
     }
 
     const handleLoading = () => {
@@ -39,17 +38,18 @@ function Button({ state, toggle = () => { }, children }) {
 
     const handleToggle = async () => {
         if (!isBlocked) {
-            toggle();
+           toggle();
+
         }
     }
 
     useEffect(() => {
-        handleButtonState();
-    }, [state])
+        handleButtonColor();
+    }, [color])
 
     return (
         <button
-            className={`w-72 sm:h-14 h-12 rounded-full cursor-blocked shadow-lg hover:opacity-80 active:scale-95 ${isBlocked ? `cursor-not-allowed active:scale-100 hover:opacity-100` : ''}`}
+            className={`loading-button w-72 sm:h-14 h-12 rounded-full shadow-lg cursor-not-allowed ${!isBlocked ? `cursor-pointer hover:opacity-80 active:scale-95` : ``}`}
             onClick={() => handleToggle()}
             style={{ backgroundColor: backgroundHex }}
         >

--- a/app/components/PlaylistContainer.jsx
+++ b/app/components/PlaylistContainer.jsx
@@ -22,7 +22,7 @@ function PlaylistContainer() {
 
     const handleSuccessCall = () => {
         setButtonColor('green');
-        setButtonText('Ready 🥳');
+        setButtonText('Ready! 🥳');
         resetButtonText();
     }
 

--- a/app/components/PlaylistContainer.jsx
+++ b/app/components/PlaylistContainer.jsx
@@ -13,7 +13,7 @@ function PlaylistContainer() {
     const { data: session } = useSession();
     const refresh_token = session?.token.accessToken;
 
-    const [buttonState, setButtonState] = useState('loading');
+    const [buttonColor, setButtonColor] = useState('gray');
     const [buttonText, setButtonText] = useState('Save this in Spotify')
 
     const handleChange = ({ target }) => {
@@ -21,23 +21,22 @@ function PlaylistContainer() {
     }
 
     const handleSuccessCall = () => {
-        setButtonState('successful');
         setButtonText('Ready 🥳');
         resetButtonText();
     }
 
     const handleErrorCall = () => {
-        setButtonState('error');
+        setButtonColor('red');
         setButtonText('Try again in a second!');
         resetButtonText();
     }
 
     const resetButtonText = () => {
-        setTimeout(()=> setButtonText('Save this in Spotify') , 4000);
+        setTimeout(()=> setButtonText('Save this in Spotify') , 2500);
     }
 
     const createPlaylist = async () => {
-        setButtonState('loading');
+        setButtonColor('gray');
         try {
             const access_token = await getAccessToken(refresh_token);
             const response = await createNewPlaylist(access_token, playlistSongs);
@@ -51,9 +50,9 @@ function PlaylistContainer() {
 
     useEffect(() => {
         if (playlistSongs.length > 0) {
-            setButtonState('successful');
+            setButtonColor('green');
         } else {
-            setButtonState('loading');
+            setButtonColor('gray');
         }
     }, [playlistSongs])
 
@@ -80,7 +79,7 @@ function PlaylistContainer() {
                     })}
                 </div>
                 <div className='w-full pt-6 flex justify-center sm:justify-end items-center ml-0 sm:ml-6'>
-                    <Button state={buttonState} toggle={() => createPlaylist()}>{buttonText}</Button>
+                    <Button color={buttonColor} toggle={() => createPlaylist()}>{buttonText}</Button>
                 </div>
             </div>
         </div>

--- a/app/components/PlaylistContainer.jsx
+++ b/app/components/PlaylistContainer.jsx
@@ -21,6 +21,7 @@ function PlaylistContainer() {
     }
 
     const handleSuccessCall = () => {
+        setButtonColor('green');
         setButtonText('Ready 🥳');
         resetButtonText();
     }
@@ -32,19 +33,21 @@ function PlaylistContainer() {
     }
 
     const resetButtonText = () => {
-        setTimeout(()=> setButtonText('Save this in Spotify') , 2500);
+        setTimeout(()=> setButtonText('Save this in Spotify') , 3000);
     }
 
     const createPlaylist = async () => {
         setButtonColor('gray');
         try {
             const access_token = await getAccessToken(refresh_token);
-            const response = await createNewPlaylist(access_token, playlistSongs);
+            const response = await createNewPlaylist(access_token, playlistName, playlistSongs);
             console.log(response);
             handleSuccessCall();
+            return response;
         } catch (e) {
             handleErrorCall();
             console.log(e);
+            return e;
         }
     }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -103,6 +103,27 @@ body::-webkit-scrollbar {
   background: #ffffff70;
 }
 
+.loading-button::after {
+  content: ' ';
+  position: absolute;
+  display: inline-block;
+  width: 0rem;
+  height: 3.8rem;
+  margin-top: -3rem;
+  margin-left: -9rem;
+  background-color: #0000006d;
+  animation: loading 3s ease-in-out;
+}
+
+@keyframes loading { 
+  0% {
+    width: 0rem;
+  }
+  100% {
+    width: 18rem;
+  }
+}
+
 @media screen and (max-width: 600px) {
 
   /*Big smartphones [426px -> 600px]*/


### PR DESCRIPTION
# About this Pull Request
I created an animation for the 'Save this in Spotify' `Button` as solution to the #26 ticket

# About this functionality 
This **animation** was created to show the users what is **happening with the creation process** of their new `playlist` and for better **user experience**. It follows the order established in the ticket: 
1. when the user's `playlists` **empty** the `Button` is totally **unclickable** and `gray`
![ButtonGray](https://github.com/Matdweb/Jamming/assets/110640534/41488aab-c08e-4f70-945f-41665cb33314)

2. when it has **at least one song**  the Button is **clickable** and `green`
![ButtonGreen](https://github.com/Matdweb/Jamming/assets/110640534/a8272351-4962-49cc-9ee7-dea2edc2338b)

3. This is how it looks when making a **successful request**: 
![createButtonAnimationTest1](https://github.com/Matdweb/Jamming/assets/110640534/e1346e4b-aed7-444d-960a-57aec2948f03)

4. This is how it should look when there's an **error in the request**
![createButtonAnimationTest2](https://github.com/Matdweb/Jamming/assets/110640534/7d99d5a6-6ba3-48dd-8642-05228d222d14)
