### PR TITLE
Fix responsive bug

### DIFF
--- a/app/components/PlaylistContainer.jsx
+++ b/app/components/PlaylistContainer.jsx
@@ -70,7 +70,7 @@ function PlaylistContainer() {
                     onChange={handleChange}
                 />
                 <hr className='w-full border-t-4 mb-4 bg-black' />
-                <div className='w-full max-h-[20rem] sm:max-h-[32rem] min-h-[20rem] sm:min-h-[32rem] overflow-y-scroll'>
+                <div className='w-full max-h-[20rem] sm:max-h-[32rem] min-h-[20rem] sm:min-h-[32rem]'>
                     {playlistSongs.map((song) => {
                         return (
                             <SongContainer

--- a/app/components/PlaylistContainer.jsx
+++ b/app/components/PlaylistContainer.jsx
@@ -70,7 +70,7 @@ function PlaylistContainer() {
                     onChange={handleChange}
                 />
                 <hr className='w-full border-t-4 mb-4 bg-black' />
-                <div className='w-full max-h-[20rem] sm:max-h-[32rem] min-h-[20rem] sm:min-h-[32rem]'>
+                <div className='w-full max-h-[20rem] sm:max-h-[32rem] min-h-[20rem] sm:min-h-[32rem] overflow-y-scroll'>
                     {playlistSongs.map((song) => {
                         return (
                             <SongContainer

--- a/app/components/SongContainer.jsx
+++ b/app/components/SongContainer.jsx
@@ -1,24 +1,24 @@
 'use client'
 import { useContext, useEffect } from 'react'
 import Image from 'next/image'
-import addIcon from '../../public/asstes/img/add.png'
-import removeIcon from '../../public/asstes/img/minus.png'
+import addIcon from '@/public/asstes/img/add.png'
+import removeIcon from '@/public/asstes/img/minus.png'
 import { SpotifyContext } from '@/context/SpotifyContextProvider'
 
 function SongContainer({ content, isRemovable = false }) {
   const { playlist: { addToPlaylist, removeFromPlaylist } } = useContext(SpotifyContext);
 
   return (
-    <div className='h-20 sm:h-24 border-b flex justify-between items-center flex-row'>
+    <div className='min-h-[5rem] sm:min-h-[6rem] border-b flex justify-between items-center flex-row'>
       <div className='pl-3 pr-9 flex justify-center items-start flex-col text-start'>
         <h4 className='song-title-bold'>{content.name}</h4>
         <p className='ligth-text'>{content.artist}  |  {content.album}</p>
       </div>
-      <span className='pr-4 cursor-pointer'>
+      <span className='pr-4 cursor-pointer shrink-0 grow-0'>
         <Image
-          className='cursor-pointer active:scale-95'
+          className='cursor-pointer active:scale-90'
           src={isRemovable ? removeIcon : addIcon}
-          alt='add icon'
+          alt='add or remove icon'
           onClick={() => {
             if(!isRemovable){
               addToPlaylist(content);


### PR DESCRIPTION
I fixed the bug from #32 ticket

## About the bug
There were actually two problems!: 
1. When the content in the `SongContainer` was bigger than `6rem`, it overflowed
2. The **add or remove** icons were **shrinking** when the screen size was reduced

## How did we solve it? 
1. we set the `height` to be just a `min-height` of `6rem`. This way the `SongContainer` will always at least be `6rem` but if the content is bigger the container will be bigger as well
2. we removed the `shrink` and the `grow` **flex properties** and now the size of the icons is fixed!

## How it looks now? 
![fixResponsiveBug](https://github.com/Matdweb/Jamming/assets/110640534/37a35e9a-9297-4c71-8f5e-51a2149b4cdd)
