### PR TITLE
Create error page

### DIFF
--- a/app/components/Background.jsx
+++ b/app/components/Background.jsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useEffect } from "react";
 
-function Background({ children }) {
+function Background({ error=false, children }) {
     const [backgroundHue, setBackgroundHue] = useState(115);
 
     const changeBackground = () => {
@@ -13,9 +13,13 @@ function Background({ children }) {
     }
 
     useEffect(() => {
-        setTimeout(() => {
-            changeBackground();
-        }, 100)
+        if (!error) {
+            setTimeout(() => {
+                changeBackground();
+            }, 100)
+        } else {
+            setBackgroundHue(0)
+        }
     }, [backgroundHue])
 
     return (

--- a/app/components/ErrorBox.jsx
+++ b/app/components/ErrorBox.jsx
@@ -1,12 +1,13 @@
 import React from 'react'
+import Link from 'next/link'
 
 function ErrorBox() {
     return (
         <div className='sm:w-[32rem] w-[19rem] h-24 bg-black outline outline-1 outline-white absolute mt-[-6rem] flex justify-start items-center'>
-            <a href='/error' className='ml-5 hover:underline'>
+            <Link href='/error' className='ml-5 hover:underline'>
                 <h4 className='song-title-bold'>Error :(</h4>
                 <p className='song-text'>There was an error creating the playlist</p>
-            </a>
+            </Link>
         </div>
     )
 }

--- a/app/components/ErrorBox.jsx
+++ b/app/components/ErrorBox.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+function ErrorBox() {
+    return (
+        <div className='sm:w-[32rem] w-[19rem] h-24 bg-black outline outline-1 outline-white absolute mt-[-6rem] flex justify-start items-center'>
+            <a href='/error' className='ml-5 hover:underline'>
+                <h4 className='song-title-bold'>Error :(</h4>
+                <p className='song-text'>There was an error creating the playlist</p>
+            </a>
+        </div>
+    )
+}
+
+export default ErrorBox

--- a/app/components/PlaylistContainer.jsx
+++ b/app/components/PlaylistContainer.jsx
@@ -44,7 +44,7 @@ function PlaylistContainer() {
         setErrorModal(false);
         try {
             const access_token = await getAccessToken(refresh_token);
-            const response = await createNewPlaylist(access_token,  playlistSongs);
+            const response = await createNewPlaylist(access_token, playlistName,  playlistSongs);
             console.log(response);
             handleSuccessCall();
             return response;

--- a/app/components/PlaylistContainer.jsx
+++ b/app/components/PlaylistContainer.jsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react"
 import SongContainer from "./SongContainer"
 import Button from "./Button";
+import ErrorBox from "./ErrorBox";
 import { useContext } from 'react';
 import { SpotifyContext } from '@/context/SpotifyContextProvider';
 import { useSession } from "next-auth/react";
@@ -14,7 +15,8 @@ function PlaylistContainer() {
     const refresh_token = session?.token.accessToken;
 
     const [buttonColor, setButtonColor] = useState('gray');
-    const [buttonText, setButtonText] = useState('Save this in Spotify')
+    const [buttonText, setButtonText] = useState('Save this in Spotify');
+    const [errorModal, setErrorModal] = useState(false);
 
     const handleChange = ({ target }) => {
         setPlaylistName(target.value);
@@ -29,22 +31,25 @@ function PlaylistContainer() {
     const handleErrorCall = () => {
         setButtonColor('red');
         setButtonText('Try again in a second!');
+        setErrorModal(true);
         resetButtonText();
     }
 
     const resetButtonText = () => {
-        setTimeout(()=> setButtonText('Save this in Spotify') , 3000);
+        setTimeout(() => setButtonText('Save this in Spotify'), 3000);
     }
 
     const createPlaylist = async () => {
         setButtonColor('gray');
+        setErrorModal(false);
         try {
             const access_token = await getAccessToken(refresh_token);
-            const response = await createNewPlaylist(access_token, playlistName, playlistSongs);
+            const response = await createNewPlaylist(access_token,  playlistSongs);
             console.log(response);
             handleSuccessCall();
             return response;
         } catch (e) {
+            setErrorModal(true);
             handleErrorCall();
             console.log(e);
             return e;
@@ -81,6 +86,9 @@ function PlaylistContainer() {
                         )
                     })}
                 </div>
+
+                {errorModal ? <ErrorBox /> : ''}
+
                 <div className='w-full pt-6 flex justify-center sm:justify-end items-center ml-0 sm:ml-6'>
                     <Button color={buttonColor} toggle={() => createPlaylist()}>{buttonText}</Button>
                 </div>

--- a/app/components/SongSearcher.jsx
+++ b/app/components/SongSearcher.jsx
@@ -5,7 +5,7 @@ import songs from '@/lib/Spotify/songs';
 
 function SongSearcher() {
     const [songName, setSongName] = useState('');
-    const { songs: { resultSongs, setResultSongs } } = useContext(SpotifyContext);
+    const { songs: { setResultSongs } } = useContext(SpotifyContext);
 
     const handleChange = ({ target }) => {
         setSongName(target.value);

--- a/app/error/page.js
+++ b/app/error/page.js
@@ -1,11 +1,46 @@
 import React from 'react'
 import Background from '../components/Background'
+import Link from 'next/link'
 
 function page() {
     return (
         <Background error={true}>
-            <div>Error page :(</div>
-        </Background>
+            <section className='w-full h-full pt-20 pl-14 sm:pl-28 pb-28'>
+                <div className='pb-14'>
+                    <h1 className='black-title'>Error :(</h1>
+                    <h2 className='header-black'>Learn more</h2>
+                </div>
+                <p className='w-11/12 mb-14'>
+                    Learn about the privacy politics of Spotify
+                    <Link href='https://www.spotify.com/cl/legal/privacy-policy/#5-c%C3%B3mo-compartimos-tus-datos-personales'> <u>here</u>.</Link>
+
+                    <br /><br />
+                    You must be sure that:
+                    <br /><br />
+                    <span className='font-bold'>
+                        1. You are giving the right permission to third-party-applications in your account settings to interact with your information. Check that <Link href='https://www.spotify.com/us/account/apps/'><u>here</u></Link>!
+                    </span>
+                    <br /><br />
+                    Otherwise we will not be able to access your data and make modifications to your account (like creating a new playlist).
+                    <br /><br />
+                    <span className='font-bold'>
+                        2. Your account didn’t automatically block ‘Jamming app’ permissions
+                    </span>
+                    <br /><br />
+                    This could happen when you make too many new playlists in a short period of time. Our recommendation is to try later.
+                    <br /><br />
+                    <span className='font-bold'>
+                        3. You didn’t block ‘Jamming app’ to connect to your Spotify as third-party-service
+                    </span>
+                    <br /><br />
+                    As you can read in the politics, Spotify gives you as a user the power to block specific third-party-services to establish connections with your account. Make sure you are not blocking the ‘Jamming app’.
+                </p>
+                <h2 className='header-black underline'>
+                    <Link href='../'>Back</Link>
+                </h2>
+            </section>
+
+        </Background >
     )
 }
 

--- a/app/error/page.js
+++ b/app/error/page.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import Background from '../components/Background'
+
+function page() {
+    return (
+        <Background error={true}>
+            <div>Error page :(</div>
+        </Background>
+    )
+}
+
+export default page

--- a/app/layout.js
+++ b/app/layout.js
@@ -2,7 +2,6 @@ import './globals.css'
 import { Inter } from 'next/font/google'
 import AuthProvider from './components/AuthProvider'
 import SpotifyContextProvider from '@/context/SpotifyContextProvider'
-import Background from './components/Background'
 
 const inter = Inter({
   subsets: ['latin'],
@@ -18,19 +17,13 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body className={inter.className}>
-        <Background>
           <AuthProvider>
             <SpotifyContextProvider>
-              <section className='text-center pt-16 sm:pt-24'>
-                <h2 className='header-black'>Create your custom playlist with</h2>
-                <h1 className='black-title'>Jamming</h1>
-              </section>
               <main>
                 {children}
               </main>
             </SpotifyContextProvider>
           </AuthProvider>
-        </Background>
       </body>
     </html >
   )

--- a/app/page.js
+++ b/app/page.js
@@ -4,20 +4,24 @@ import Login from './components/Login'
 import SongSearcher from './components/SongSearcher';
 import SongsContainer from './components/SongsContainer';
 import PlaylistContainer from './components/PlaylistContainer';
+import Background from './components/Background';
 
 export default function Home() {
   const { data: session } = useSession();
-  if (session) {
-    return (
+  return (
+    <Background>
       <div>
-        <section className='w-full h-full flex justify-center items-start flex-row flex-wrap md:mt-24 mt-16 pb-32'>
-          <SongSearcher />
-          <SongsContainer />
-          <PlaylistContainer />
+        <section className='text-center pt-16 sm:pt-24'>
+          <h2 className='header-black'>Create your custom playlist with</h2>
+          <h1 className='black-title'>Jamming</h1>
         </section>
+        {!session ? <Login /> :
+          <section className='w-full h-full flex justify-center items-start flex-row flex-wrap md:mt-24 mt-16 pb-32'>
+            <SongSearcher />
+            <SongsContainer />
+            <PlaylistContainer />
+          </section>}
       </div>
-    )
-  } else {
-    return <Login />
-  }
+    </Background>
+  )
 }

--- a/context/SpotifyContextProvider.jsx
+++ b/context/SpotifyContextProvider.jsx
@@ -1,5 +1,5 @@
 'use client'
-import { createContext, useEffect, useState } from 'react'
+import { createContext, useState } from 'react'
 import requestAccessToken from '@/lib/Spotify/getAccessToken/requestAccessToken';
 
 export const SpotifyContext = createContext()


### PR DESCRIPTION
# About `/error` page
I created an `error-page` for when the API requests fail! ❌ 
This page answers the question:  **why would the creation of your playlists could be falling?** 

# Why would the creation of the playlists could be falling?
- This page provides the [spotify-privacy-politcs](https://www.spotify.com/cl/legal/privacy-policy/#5-c%C3%B3mo-compartimos-tus-datos-personales) link for the users to be aware of the Spotify politics and how does `Jamming` work with their data ℹ️ 
- This page also provides a link to the `mange-apps` spotify settings section, I attached it [here](https://www.spotify.com/us/account/apps/). 
This links **redirects users** to their **account settings** letting them know wich `third-party-applications` they are giving permission to. This, in order for them to check whether this `Jamming` app has **permissions or not**
- This page gives the user the common reasons for: **Why could this request be failing?**

>    1. You are not giving the right permission to `third-party-applications` in your account settings to interact with the information.
>    2. Your account automatically blocked ‘Jamming app’ permissions
>    3. You blocked ‘Jamming app’ to connect to your Spotify as `third-party-service`

# About `/error` endpoint
When there's an error here the page displays this element
![image](https://github.com/Matdweb/Jamming/assets/110640534/00b50238-4656-427c-b1ae-004dd806717b)
If you click it it will redirect you to the `/error` endpoint of this app. Here's where all the this info is provided 📄 

# Test
See how this functionality works: 
![createErrorPage](https://github.com/Matdweb/Jamming/assets/110640534/1aff9749-26c9-4f52-be69-985a476a3055)
